### PR TITLE
Fix incorrect use of lstrip in run.py split_full_path()

### DIFF
--- a/run.py
+++ b/run.py
@@ -41,7 +41,7 @@ def split_full_path(path):
     if path.startswith('s3://'):
         path = path[len('s3://'):]
     elif path.startswith('s3n://'):
-        path = path[len('s3://'):]
+        path = path[len('s3n://'):]
     else:
         raise ValueError("S3 path should start with s3:// or s3n:// prefix")
     parts = path.split('/')

--- a/run.py
+++ b/run.py
@@ -39,9 +39,9 @@ def split_full_path(path):
     ('mybucket', None)
     """
     if path.startswith('s3://'):
-        path = path.lstrip('s3://')
+        path = path[len('s3://'):]
     elif path.startswith('s3n://'):
-        path = path.lstrip('s3n://')
+        path = path[len('s3://'):]
     else:
         raise ValueError("S3 path should start with s3:// or s3n:// prefix")
     parts = path.split('/')

--- a/run.py
+++ b/run.py
@@ -38,10 +38,10 @@ def split_full_path(path):
     >>> split_full_path('s3://mybucket')
     ('mybucket', None)
     """
-    if path.startswith('s3://'):
-        path = path[len('s3://'):]
-    elif path.startswith('s3n://'):
-        path = path[len('s3n://'):]
+    for prefix in ['s3://', 's3n://']:
+        if path.startswith(prefix):
+            path = path[len(prefix):]
+            break
     else:
         raise ValueError("S3 path should start with s3:// or s3n:// prefix")
     parts = path.split('/')


### PR DESCRIPTION
Current version of run.py uses string lstrip method in split_full_path(), will remove leading "s"s and "3"s from bucket name.
```
In [8]: run.split_full_path('s3://sss333abc/foo/bar')
Out[8]: ('abc', 'foo/bar/')
```



