### PR TITLE
Specify DeleteItem rights to avoid 'step failure'

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ event-manifest-cleaner directory):
 $ python run.py run_emr $ENRICHED_EVENTS_DIR $STORAGE_CONFIG_PATH $IGLU_RESOLVER_PATH
 ```
 
+The user running it should have the _dynamodb:DeleteTable_ rights for the related table.
+
 Task has three required arguments: 
 
 1. Path to enriched events directory. This can be not archived directory in 


### PR DESCRIPTION
An ```AmazonDynamoDBException``` was found in the ```logs/j-2E8P7CMXXXX/containers/application_1516800752163_0001/container_1516800752163_0001_01_000001/stderr.gz log ``` and was due to a missing dynamodb:DeleteItem right.

You could also add it in the [Setting up Amazon DynamoDB >  Setting up IAM Policy](https://github.com/snowplow/snowplow/wiki/Setting-up-Amazon-DynamoDB#2-setting-up-iam-policy) wiki page.