### PR TITLE
Show cluster to all users by default.

### DIFF
--- a/run.py
+++ b/run.py
@@ -178,6 +178,7 @@ def run_emr(args):
         steps=steps,
         job_flow_role="EMR_EC2_DefaultRole",
         service_role="EMR_DefaultRole",
+        visible_to_all_users=True,
         api_params={
             'ReleaseLabel': 'emr-5.4.0',
             'Applications.member.1.Name': 'Spark',


### PR DESCRIPTION
Why to keep this job hidden by default?
A parameter could be added later to override this value (hide to all).

When I was trying to find [why my cluster failed](https://github.com/snowplow/event-manifest-cleaner/pull/5) I notice all other users in the aws account could not see the job.